### PR TITLE
Fix versão de fix_mysql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.27</version>
+            <version>8.0.28</version>
         </dependency>
 		<dependency>
 			<groupId>org.jacoco</groupId>


### PR DESCRIPTION
mysql-connector-java:
- v8.0.27 para v8.0.28
- Dependência com vulnerabilidade
